### PR TITLE
Strip whitespace from version text

### DIFF
--- a/generate_feed.rb
+++ b/generate_feed.rb
@@ -81,7 +81,7 @@ if !File.exist?(FILENAME)
   init_feed
 else
   doc = Hpricot(open("http://git-scm.com/"))
-  ver = doc.at("span.version").inner_text
+  ver = doc.at("span.version").inner_text.strip
 
   if is_new ver
     puts "*** New version #{ver} found, adding to feed ***"


### PR DESCRIPTION
This commit added whitespace around the version number on the Git homepage, which stops the release notes URL from being built correctly: https://github.com/git/git-scm.com/commit/242783421bc7c98f6d0300404ea243a92784161c
