### PR TITLE
Fetch Git homepage over HTTPS

### DIFF
--- a/generate_feed.rb
+++ b/generate_feed.rb
@@ -80,7 +80,7 @@ if !File.exist?(FILENAME)
   puts "*** Feed doesn't exist yet, initialising ***"
   init_feed
 else
-  doc = Hpricot(open("http://git-scm.com/"))
+  doc = Hpricot(open("https://git-scm.com/"))
   ver = doc.at("span.version").inner_text.strip
 
   if is_new ver


### PR DESCRIPTION
The Git homepage now redirects HTTP requests to HTTPS: https://github.com/git/git-scm.com/commit/ff1a02f6f6e26700bcab7ae0a44d623bba50b9ba

This broke the script, as `open-uri` doesn't allow such redirects:

```
`open_loop': redirection forbidden: http://git-scm.com/ -> https://git-scm.com/ (RuntimeError)
```
